### PR TITLE
feat(cache): prerender crawler-visible law routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "start": "next start",
     "test": "tsx --test src/**/*.test.ts",
     "typecheck": "tsc --noEmit",
-    "prebuild": "node scripts/build-law-index.mjs",
-    "predev": "node scripts/build-law-index.mjs"
+    "prebuild": "node scripts/build-law-index.mjs && node scripts/build-law-prerender-manifest.mjs",
+    "predev": "node scripts/build-law-index.mjs && node scripts/build-law-prerender-manifest.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",

--- a/scripts/build-law-prerender-manifest.mjs
+++ b/scripts/build-law-prerender-manifest.mjs
@@ -1,0 +1,132 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const GENERATED_DIR = path.resolve("src/generated");
+const LAW_INDEX_FILE = path.join(GENERATED_DIR, "law-index.json");
+const OUTPUT_FILE = path.join(GENERATED_DIR, "law-prerender-manifest.json");
+
+const PROXY_URL = process.env.GESETZE_PROXY_URL;
+const PROXY_API_KEY = process.env.GESETZE_PROXY_API_KEY;
+const BASE_URL = "https://www.gesetze-im-internet.de";
+const FETCH_CONCURRENCY = 8;
+
+function readLawIndex() {
+  if (!fs.existsSync(LAW_INDEX_FILE)) {
+    throw new Error(
+      `Missing ${LAW_INDEX_FILE}. Run build-law-index before generating the prerender manifest.`,
+    );
+  }
+
+  return JSON.parse(fs.readFileSync(LAW_INDEX_FILE, "utf8"));
+}
+
+function buildFetchUrl(lawCode) {
+  const lawIndexPath = `${lawCode}/index.html`;
+  if (PROXY_URL && PROXY_API_KEY) {
+    return `${PROXY_URL}/${lawIndexPath}`;
+  }
+
+  return `${BASE_URL}/${lawIndexPath}`;
+}
+
+async function fetchLawIndexHtml(lawCode) {
+  const headers = {};
+  if (PROXY_URL && PROXY_API_KEY) {
+    headers["X-API-Key"] = PROXY_API_KEY;
+  }
+
+  const response = await fetch(buildFetchUrl(lawCode), { headers });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${lawCode}/index.html: ${response.status}`);
+  }
+
+  const buffer = await response.arrayBuffer();
+  return new TextDecoder("iso-8859-1").decode(buffer);
+}
+
+function parseParagraphs(html) {
+  const paragraphIds = new Set();
+
+  for (const match of html.matchAll(/href="(__[^"#?]+\.html)"/g)) {
+    const href = match[1];
+    if (!href) continue;
+
+    const paragraphId = href.replace(/^__/, "").replace(/\.html$/, "").toLowerCase();
+    if (!paragraphId) continue;
+
+    paragraphIds.add(paragraphId);
+  }
+
+  return [...paragraphIds];
+}
+
+async function mapWithConcurrency(items, limit, mapper) {
+  const results = new Array(items.length);
+  let currentIndex = 0;
+
+  async function worker() {
+    while (currentIndex < items.length) {
+      const index = currentIndex++;
+      results[index] = await mapper(items[index], index);
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}
+
+async function buildManifest() {
+  const lawIndex = readLawIndex();
+  const laws = Array.isArray(lawIndex.laws) ? lawIndex.laws : [];
+
+  console.log(`[build-law-prerender-manifest] Generating manifest for ${laws.length} laws`);
+
+  const lawEntries = await mapWithConcurrency(
+    laws,
+    FETCH_CONCURRENCY,
+    async (law, index) => {
+      try {
+        const html = await fetchLawIndexHtml(law.code);
+        const paragraphs = parseParagraphs(html);
+
+        if ((index + 1) % 100 === 0 || index === laws.length - 1) {
+          console.log(
+            `[build-law-prerender-manifest] Processed ${index + 1}/${laws.length} laws`,
+          );
+        }
+
+        return {
+          code: law.code,
+          paragraphs,
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(
+          `[build-law-prerender-manifest] Skipping ${law.code}: ${message}`,
+        );
+        return {
+          code: law.code,
+          paragraphs: [],
+        };
+      }
+    },
+  );
+
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    sourceLawIndexGeneratedAt:
+      typeof lawIndex.generatedAt === "string" ? lawIndex.generatedAt : null,
+    lawCount: lawEntries.length,
+    routeCount: lawEntries.reduce((sum, law) => sum + law.paragraphs.length, 0),
+    laws: lawEntries.filter((law) => law.paragraphs.length > 0),
+  };
+
+  fs.mkdirSync(GENERATED_DIR, { recursive: true });
+  fs.writeFileSync(OUTPUT_FILE, JSON.stringify(manifest, null, 2), "utf8");
+
+  console.log(
+    `[build-law-prerender-manifest] Wrote ${manifest.routeCount} routes across ${manifest.laws.length} laws -> ${OUTPUT_FILE}`,
+  );
+}
+
+await buildManifest();

--- a/src/app/[law]/[paragraph]/page.tsx
+++ b/src/app/[law]/[paragraph]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 
 import KeyboardNavigation from "./KeyboardNavigation";
 import { Button } from "@/components/ui/button";
+import { getPrerenderManifest } from "@/lib/gesetze/prerender-routes";
 import {
   buildParagraphSourceUrl,
   fetchParagraphRecord,
@@ -10,6 +11,19 @@ import {
 import { SOURCE_REVALIDATE_SECONDS } from "@/lib/source-cache";
 
 export const dynamic = "force-static";
+export const dynamicParams = true;
+export const revalidate = SOURCE_REVALIDATE_SECONDS;
+
+export function generateStaticParams(): PageParams[] {
+  const manifest = getPrerenderManifest();
+
+  return (manifest.laws ?? []).flatMap((law) =>
+    (law.paragraphs ?? []).map((paragraph) => ({
+      law: law.code,
+      paragraph,
+    })),
+  );
+}
 
 type PageParams = {
   law: string;

--- a/src/lib/gesetze/prerender-routes.ts
+++ b/src/lib/gesetze/prerender-routes.ts
@@ -1,0 +1,28 @@
+import prerenderManifest from "@/generated/law-prerender-manifest.json";
+
+export interface PrerenderManifestLaw {
+  code: string;
+  paragraphs?: string[];
+}
+
+export interface PrerenderManifest {
+  generatedAt?: string;
+  sourceLawIndexGeneratedAt?: string | null;
+  lawCount?: number;
+  routeCount?: number;
+  laws?: PrerenderManifestLaw[];
+}
+
+const manifest = prerenderManifest as PrerenderManifest;
+
+const prerenderedParagraphsByLaw = new Map(
+  (manifest.laws ?? []).map((law) => [law.code, new Set(law.paragraphs ?? [])]),
+);
+
+export function getPrerenderManifest(): PrerenderManifest {
+  return manifest;
+}
+
+export function isPrerenderedRoute(law: string, paragraph: string): boolean {
+  return prerenderedParagraphsByLaw.get(law)?.has(paragraph) ?? false;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,8 +1,30 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
+import { isPrerenderedRoute } from "@/lib/gesetze/prerender-routes";
+
+const CLAUDE_BOT_PATTERN = /(claudebot|anthropic-ai)/i;
+
 export function middleware(request: NextRequest) {
+  const userAgent = request.headers.get("user-agent") ?? "";
+  const isClaudeBot = CLAUDE_BOT_PATTERN.test(userAgent);
   const acceptHeader = request.headers.get("accept") ?? "";
+
+  if (isClaudeBot) {
+    const routeMatch = /^\/([^/]+)\/([^/]+)$/.exec(request.nextUrl.pathname);
+    const law = routeMatch?.[1]?.toLowerCase() ?? "";
+    const paragraph = routeMatch?.[2]?.toLowerCase() ?? "";
+
+    if (law && paragraph && !isPrerenderedRoute(law, paragraph)) {
+      return new NextResponse("Not prerendered for crawler access.", {
+        status: 404,
+        headers: {
+          "Content-Type": "text/plain; charset=utf-8",
+          "X-Robots-Tag": "noindex",
+        },
+      });
+    }
+  }
 
   // Check if client accepts markdown
   const wantsMarkdown =

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -56,9 +56,14 @@ export default {
     }
 
     // Validate path format to prevent abuse (allow law paths and Teilliste)
-    const lawPathPattern = /^[a-z0-9_-]+\/__[a-z0-9_-]+\.html$/i;
+    const lawParagraphPathPattern = /^[a-z0-9_-]+\/__[a-z0-9_-]+\.html$/i;
+    const lawIndexPathPattern = /^[a-z0-9_-]+\/index\.html$/i;
     const teillistePattern = /^Teilliste_[A-Z1-9]\.html$/;
-    if (!lawPathPattern.test(path) && !teillistePattern.test(path)) {
+    if (
+      !lawParagraphPathPattern.test(path) &&
+      !lawIndexPathPattern.test(path) &&
+      !teillistePattern.test(path)
+    ) {
       return new Response(JSON.stringify({ error: "Invalid path format" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- add a build-time prerender manifest for known law paragraph routes
- prerender known routes while keeping ISR fallback for humans
- block Claude/Anthropic crawler requests from triggering generation on non-prerendered routes

## Verification
- pnpm prebuild
- pnpm typecheck
- pnpm test
- pnpm lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented route prerendering for optimized delivery of law and paragraph pages.

* **Chores**
  * Enhanced build pipeline with automatic prerender manifest generation.
  * Improved crawler handling with comprehensive route validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->