### PR TITLE
feat(mcp): add full-text legal search

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ Current scope:
 
 - local law directory search
 - live exact paragraph retrieval from `gesetze-im-internet.de`
+- live upstream full-text search across legal texts
 - streamable HTTP transport at `/mcp`
 - `stdio` transport for local development
-- no global full-text search across all legal text yet
 
 The MCP server reuses the same shared parsing layer as the web app, so the app
 routes and MCP tools stay in sync.
@@ -105,6 +105,7 @@ https://your-domain.example/mcp
 ### Tool List
 
 - `search_laws`
+- `search_full_text`
 - `resolve_reference`
 - `get_law_info`
 - `get_paragraph`
@@ -187,6 +188,55 @@ Behavior:
 - uses the local generated law directory
 - defaults `limit` to `10`
 - caps `limit` at `25`
+
+#### `search_full_text`
+
+Search the full text of legal documents via the official upstream full-text
+search.
+
+Input:
+
+```json
+{
+  "query": "kaufvertrag",
+  "method": "and",
+  "page": 1
+}
+```
+
+Output shape:
+
+```json
+{
+  "query": "kaufvertrag",
+  "method": "and",
+  "page": 1,
+  "total": 48,
+  "start": 1,
+  "end": 10,
+  "count": 10,
+  "results": [
+    {
+      "law": "bgb",
+      "paragraph": "433",
+      "citation": "BGB § 433",
+      "title": "§ 433 BGB - Einzelnorm",
+      "snippet": "BÜRGERLICHES GESETZBUCH (BGB) § 433 **KAUFVERTRAG** ...",
+      "sourceUrl": "https://www.gesetze-im-internet.de/bgb/__433.html",
+      "canonicalUrl": "https://gesetz.sh/bgb/433",
+      "score": 4
+    }
+  ]
+}
+```
+
+Behavior:
+
+- uses the official `Volltextsuche` endpoint upstream
+- supports `method: "and" | "or"`
+- supports `page` values from `1` to `100`
+- returns normalized `law` and `paragraph` fields when the hit points to a
+  concrete paragraph page
 
 #### `resolve_reference`
 

--- a/src/lib/gesetze/full-text-search.test.ts
+++ b/src/lib/gesetze/full-text-search.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 
 import { parseFullTextSearchHtml } from "./full-text-search";
 
-test("parseFullTextSearchHtml parses paragraph hits", () => {
+void test("parseFullTextSearchHtml parses paragraph hits", () => {
   const html = `
     <div id="paddingLR12">
       <h2>Trefferliste f&uuml;r 'kaufvertrag'</h2>
@@ -58,7 +58,7 @@ test("parseFullTextSearchHtml parses paragraph hits", () => {
   });
 });
 
-test("parseFullTextSearchHtml handles no results pages", () => {
+void test("parseFullTextSearchHtml handles no results pages", () => {
   const html = `
     <div id="paddingLR12">
       <h2 class="rot">Keine Treffer gefunden f&uuml;r 'foo'</h2>

--- a/src/lib/gesetze/full-text-search.test.ts
+++ b/src/lib/gesetze/full-text-search.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseFullTextSearchHtml } from "./full-text-search";
+
+test("parseFullTextSearchHtml parses paragraph hits", () => {
+  const html = `
+    <div id="paddingLR12">
+      <h2>Trefferliste f&uuml;r 'kaufvertrag'</h2>
+      <strong>Dokument 1 - 2 von 48 Treffer, je mehr <img src="/htdig/star.gif" alt="*">, umso h&ouml;her die Genauigkeit.</strong>
+      <dl>
+        <dt>
+          <strong>
+            <a href="https://www.gesetze-im-internet.de/bgb/__433.html">&sect; 433 BGB - Einzelnorm</a>
+          </strong>
+          <img src="/htdig/star.gif" alt="*">
+          <img src="/htdig/star.gif" alt="*">
+          <img src="/htdig/star_blank.gif" alt=" ">
+        </dt>
+        <dd>zur&uuml;ck weiter Nichtamtliches Inhaltsverzeichnis B&Uuml;RGERLICHES GESETZBUCH (BGB) &sect; 433 <strong>Kaufvertrag</strong> ...</dd>
+      </dl>
+      <dl>
+        <dt>
+          <strong>
+            <a href="https://www.gesetze-im-internet.de/vermbg_2/">5. VermBG - nichtamtliches Inhaltsverzeichnis</a>
+          </strong>
+          <img src="/htdig/star.gif" alt="*">
+        </dt>
+        <dd><strong><code>... </code></strong> Wertpapier-<strong>Kaufvertrag</strong></dd>
+      </dl>
+    </div>
+  `;
+
+  const result = parseFullTextSearchHtml(html, "Kaufvertrag", "and", 1);
+
+  assert.equal(result.query, "Kaufvertrag");
+  assert.equal(result.total, 48);
+  assert.equal(result.start, 1);
+  assert.equal(result.end, 2);
+  assert.equal(result.results.length, 2);
+  assert.deepEqual(result.results[0], {
+    law: "bgb",
+    paragraph: "433",
+    citation: "BGB § 433",
+    title: "§ 433 BGB - Einzelnorm",
+    snippet: "BÜRGERLICHES GESETZBUCH (BGB) § 433 **Kaufvertrag** ...",
+    sourceUrl: "https://www.gesetze-im-internet.de/bgb/__433.html",
+    canonicalUrl: "https://gesetz.sh/bgb/433",
+    score: 2,
+  });
+  assert.deepEqual(result.results[1], {
+    law: "vermbg_2",
+    title: "5. VermBG - nichtamtliches Inhaltsverzeichnis",
+    snippet: "... Wertpapier-**Kaufvertrag**",
+    sourceUrl: "https://www.gesetze-im-internet.de/vermbg_2/",
+    canonicalUrl: "https://gesetz.sh/vermbg_2/1",
+    score: 1,
+  });
+});
+
+test("parseFullTextSearchHtml handles no results pages", () => {
+  const html = `
+    <div id="paddingLR12">
+      <h2 class="rot">Keine Treffer gefunden f&uuml;r 'foo'</h2>
+    </div>
+  `;
+
+  const result = parseFullTextSearchHtml(html, "foo", "or", 3);
+
+  assert.deepEqual(result, {
+    query: "foo",
+    method: "or",
+    page: 3,
+    total: 0,
+    start: 0,
+    end: 0,
+    results: [],
+  });
+});

--- a/src/lib/gesetze/full-text-search.ts
+++ b/src/lib/gesetze/full-text-search.ts
@@ -1,0 +1,209 @@
+import { parse } from "node-html-parser";
+
+import {
+  buildCanonicalUrl,
+  buildParagraphCitation,
+  normalizeLawCode,
+  normalizeParagraphId,
+} from "./reference";
+import { getLawCanonicalUrl } from "./law-directory";
+
+const DOMAIN = "https://www.gesetze-im-internet.de";
+const REQUEST_HEADERS: Record<string, string> = {
+  "User-Agent":
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) GesetzeNext/1.0 Chrome/120.0.0.0 Safari/537.36",
+  Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+  "Accept-Language": "de-DE,de;q=0.9,en;q=0.8",
+};
+
+export type FullTextSearchMethod = "and" | "or";
+
+export interface FullTextSearchResult {
+  law?: string;
+  paragraph?: string;
+  citation?: string;
+  title: string;
+  snippet: string;
+  sourceUrl: string;
+  canonicalUrl?: string;
+  score: number;
+}
+
+export interface FullTextSearchResponse {
+  query: string;
+  method: FullTextSearchMethod;
+  page: number;
+  total: number;
+  start: number;
+  end: number;
+  results: FullTextSearchResult[];
+}
+
+function getProxyConfig() {
+  const url = process.env.GESETZE_PROXY_URL;
+  const apiKey = process.env.GESETZE_PROXY_API_KEY;
+
+  if (!url || !apiKey) {
+    return null;
+  }
+
+  return { url, apiKey };
+}
+
+function normalizeText(value: string): string {
+  return value.replace(/\u00a0/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function decodeHtml(value: string): string {
+  return parse(`<span>${value}</span>`).textContent;
+}
+
+function htmlSnippetToMarkdown(value: string): string {
+  const withoutBoilerplate = value
+    .replace(/^(\s*zur&uuml;ck\s+weiter\s+)?Nichtamtliches Inhaltsverzeichnis\s*/i, "")
+    .replace(/<strong><code>\s*\.\.\.\s*<\/code><\/strong>/gi, "...")
+    .replace(/<\/?(code)>/gi, "");
+
+  return normalizeText(
+    decodeHtml(
+      withoutBoilerplate
+        .replace(/<\/?(strong|b)>/gi, "**")
+        .replace(/<br\s*\/?>/gi, "\n")
+        .replace(/<[^>]+>/g, " "),
+    ),
+  );
+}
+
+function parseResultUrl(value: string): Pick<
+  FullTextSearchResult,
+  "law" | "paragraph" | "citation" | "canonicalUrl"
+> {
+  try {
+    const url = new URL(value);
+    const paragraphMatch = /^\/([a-z0-9_-]+)\/__([a-z0-9_-]+)\.html$/i.exec(url.pathname);
+    if (paragraphMatch) {
+      const law = normalizeLawCode(paragraphMatch[1] ?? "");
+      const paragraph = normalizeParagraphId(paragraphMatch[2] ?? "");
+      return {
+        law,
+        paragraph,
+        citation: buildParagraphCitation(law, paragraph),
+        canonicalUrl: buildCanonicalUrl(law, paragraph),
+      };
+    }
+
+    const lawMatch = /^\/([a-z0-9_-]+)\/$/i.exec(url.pathname);
+    if (lawMatch) {
+      const law = normalizeLawCode(lawMatch[1] ?? "");
+      return {
+        law,
+        canonicalUrl: getLawCanonicalUrl(law),
+      };
+    }
+
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+export function parseFullTextSearchHtml(
+  htmlText: string,
+  requestedQuery: string,
+  method: FullTextSearchMethod,
+  page: number,
+): FullTextSearchResponse {
+  const root = parse(htmlText);
+  const padding = root.querySelector("#paddingLR12");
+
+  const noResultsHeading = padding?.querySelector("h2.rot")?.textContent;
+  if (noResultsHeading) {
+    return {
+      query: requestedQuery,
+      method,
+      page,
+      total: 0,
+      start: 0,
+      end: 0,
+      results: [],
+    };
+  }
+
+  const summaryText = padding?.querySelector("strong")?.textContent ?? "";
+  const summaryMatch = /Dokument\s+(\d+)\s*-\s*(\d+)\s+von\s+(\d+)\s+Treffer/i.exec(summaryText);
+
+  const results = (padding?.querySelectorAll("dl") ?? []).flatMap((entry) => {
+    const link = entry.querySelector("dt a");
+    const snippetNode = entry.querySelector("dd");
+    if (!link || !snippetNode) return [];
+
+    const sourceUrl = link.getAttribute("href")?.trim();
+    if (!sourceUrl) return [];
+
+    const score = entry
+      .querySelectorAll("dt img")
+      .filter((image) => (image.getAttribute("src") ?? "").includes("star.gif")).length;
+
+    return [
+      {
+        ...parseResultUrl(sourceUrl),
+        title: normalizeText(decodeHtml(link.textContent ?? "")),
+        snippet: htmlSnippetToMarkdown(snippetNode.innerHTML),
+        sourceUrl,
+        score,
+      },
+    ];
+  });
+
+  return {
+    query: requestedQuery,
+    method,
+    page,
+    total: summaryMatch ? Number(summaryMatch[3]) : results.length,
+    start: summaryMatch ? Number(summaryMatch[1]) : results.length > 0 ? 1 : 0,
+    end: summaryMatch ? Number(summaryMatch[2]) : results.length,
+    results,
+  };
+}
+
+export async function searchFullText(
+  query: string,
+  options: {
+    method?: FullTextSearchMethod;
+    page?: number;
+  } = {},
+): Promise<FullTextSearchResponse> {
+  const method = options.method ?? "and";
+  const page = options.page ?? 1;
+  const proxy = getProxyConfig();
+
+  const params = new URLSearchParams({
+    config: "Gesamt_bmjhome2005",
+    method,
+    words: query,
+  });
+
+  if (page > 1) {
+    params.set("page", String(page));
+  }
+
+  const fetchUrl = proxy
+    ? `${proxy.url}/cgi-bin/htsearch?${params.toString()}`
+    : `${DOMAIN}/cgi-bin/htsearch?${params.toString()}`;
+
+  const headers = { ...REQUEST_HEADERS };
+  if (proxy) {
+    headers["X-API-Key"] = proxy.apiKey;
+  }
+
+  const response = await fetch(fetchUrl, { headers });
+  if (!response.ok) {
+    throw new Error(`Full-text search failed with status ${response.status}.`);
+  }
+
+  const buffer = await response.arrayBuffer();
+  const decoder = new TextDecoder("iso-8859-1");
+  const htmlText = decoder.decode(buffer);
+
+  return parseFullTextSearchHtml(htmlText, query, method, page);
+}

--- a/src/lib/gesetze/law-directory.ts
+++ b/src/lib/gesetze/law-directory.ts
@@ -1,4 +1,4 @@
-import lawIndexData from "../../generated/law-index.json";
+import lawIndexData from "../../generated/law-index.json" with { type: "json" };
 
 export interface LawDirectoryEntry {
   code: string;

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -21,6 +21,7 @@ import {
   fetchParagraphRecord,
   paragraphRecordToMarkdown,
 } from "./gesetze/paragraph-source";
+import { searchFullText } from "./gesetze/full-text-search";
 
 const lawDirectory = loadLawDirectory();
 const aliasEntries = buildLawAliasEntries(lawDirectory.laws);
@@ -48,6 +49,17 @@ const paragraphResultSchema = z.object({
   }),
   sourceUrl: z.string().url(),
   canonicalUrl: z.string().url(),
+});
+
+const fullTextSearchResultSchema = z.object({
+  law: z.string().optional(),
+  paragraph: z.string().optional(),
+  citation: z.string().optional(),
+  title: z.string(),
+  snippet: z.string(),
+  sourceUrl: z.string().url(),
+  canonicalUrl: z.string().url().optional(),
+  score: z.number().int(),
 });
 
 function errorResult(text: string) {
@@ -153,6 +165,68 @@ export function createMcpServer() {
         content: [{ type: "text" as const, text: summary }],
         structuredContent,
       };
+    },
+  );
+
+  server.registerTool(
+    "search_full_text",
+    {
+      title: "Search Full Text",
+      description:
+        "Search across the full text of all legal documents using the official upstream full-text search.",
+      annotations: readOnlyAnnotations("Search Full Text", true),
+      inputSchema: {
+        query: z.string().min(1).describe("Full-text query"),
+        method: z
+          .enum(["and", "or"])
+          .optional()
+          .describe("Whether all words must match or any word may match"),
+        page: z.number().int().min(1).max(100).optional(),
+      },
+      outputSchema: {
+        query: z.string(),
+        method: z.enum(["and", "or"]),
+        page: z.number().int(),
+        total: z.number().int(),
+        start: z.number().int(),
+        end: z.number().int(),
+        count: z.number().int(),
+        results: z.array(fullTextSearchResultSchema),
+      },
+    },
+    async ({ query, method = "and", page = 1 }) => {
+      try {
+        const search = await searchFullText(query, { method, page });
+        const structuredContent = {
+          ...search,
+          count: search.results.length,
+        };
+
+        const summary =
+          search.results.length > 0
+            ? search.results
+                .map((result) =>
+                  [
+                    result.citation ?? result.law?.toUpperCase() ?? result.title,
+                    result.title,
+                    result.snippet,
+                    result.canonicalUrl ?? result.sourceUrl,
+                  ]
+                    .filter(Boolean)
+                    .join("\n"),
+                )
+                .join("\n\n")
+            : `No legal text matched "${query}".`;
+
+        return {
+          content: [{ type: "text" as const, text: summary }],
+          structuredContent,
+        };
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Unknown full-text search error.";
+        return errorResult(message);
+      }
     },
   );
 

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import * as z from "zod/v3";
 
 import {
@@ -92,6 +93,18 @@ function toParagraphResult(record: NonNullable<Awaited<ReturnType<typeof fetchPa
   };
 }
 
+function readOnlyAnnotations(
+  title: string,
+  openWorldHint = false,
+): ToolAnnotations {
+  return {
+    title,
+    readOnlyHint: true,
+    idempotentHint: true,
+    openWorldHint,
+  };
+}
+
 export function createMcpServer() {
   const server = new McpServer({
     name: "gesetze",
@@ -104,6 +117,7 @@ export function createMcpServer() {
       title: "Search Laws",
       description:
         "Search the local law directory by law code, title, full title, or description.",
+      annotations: readOnlyAnnotations("Search Laws"),
       inputSchema: {
         query: z.string().min(1).describe("Law search query"),
         limit: z.number().int().min(1).max(25).optional(),
@@ -148,6 +162,7 @@ export function createMcpServer() {
       title: "Resolve Reference",
       description:
         "Resolve a loose legal reference such as 'bgb 433', 'bgb§433', or '§ 433' into a canonical law and paragraph path.",
+      annotations: readOnlyAnnotations("Resolve Reference"),
       inputSchema: {
         input: z.string().min(1).describe("Loose legal reference"),
         currentLaw: z.string().optional().describe("Fallback law code"),
@@ -198,6 +213,7 @@ export function createMcpServer() {
     {
       title: "Get Law Info",
       description: "Get directory metadata for an exact law code.",
+      annotations: readOnlyAnnotations("Get Law Info"),
       inputSchema: {
         law: z.string().min(1).describe("Law code, e.g. bgb"),
       },
@@ -235,6 +251,7 @@ export function createMcpServer() {
       title: "Get Paragraph",
       description:
         "Fetch the exact text of a legal paragraph with headers, content, footnotes, and neighboring paragraph ids.",
+      annotations: readOnlyAnnotations("Get Paragraph", true),
       inputSchema: {
         law: z.string().min(1).describe("Law code, e.g. bgb"),
         paragraph: z.string().min(1).describe("Paragraph id, e.g. 433"),
@@ -267,6 +284,7 @@ export function createMcpServer() {
       title: "Get Paragraphs",
       description:
         "Fetch multiple exact legal paragraphs in a single tool call. Individual failures are returned per item.",
+      annotations: readOnlyAnnotations("Get Paragraphs", true),
       inputSchema: {
         items: z
           .array(
@@ -346,6 +364,7 @@ export function createMcpServer() {
       title: "Navigate Paragraph",
       description:
         "Resolve the previous or next valid paragraph using upstream navigation links instead of guessing numeric neighbors.",
+      annotations: readOnlyAnnotations("Navigate Paragraph", true),
       inputSchema: {
         law: z.string().min(1),
         paragraph: z.string().min(1),
@@ -417,6 +436,7 @@ export function createMcpServer() {
       title: "Extract Citations",
       description:
         "Extract simple paragraph citations such as '§ 433' from free text and optionally attach the current law as context.",
+      annotations: readOnlyAnnotations("Extract Citations"),
       inputSchema: {
         text: z.string().min(1),
         currentLaw: z.string().optional(),

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -55,10 +55,15 @@ export default {
       });
     }
 
-    // Validate path format to prevent abuse (allow law paths and Teilliste)
+    // Validate path format to prevent abuse (allow law paths, Teilliste, and full-text search)
     const lawPathPattern = /^[a-z0-9_-]+\/__[a-z0-9_-]+\.html$/i;
     const teillistePattern = /^Teilliste_[A-Z1-9]\.html$/;
-    if (!lawPathPattern.test(path) && !teillistePattern.test(path)) {
+    const fullTextSearchPath = /^cgi-bin\/htsearch$/;
+    if (
+      !lawPathPattern.test(path) &&
+      !teillistePattern.test(path) &&
+      !fullTextSearchPath.test(path)
+    ) {
       return new Response(JSON.stringify({ error: "Invalid path format" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
@@ -66,7 +71,7 @@ export default {
     }
 
     try {
-      const targetUrl = `${UPSTREAM_BASE}/${path}`;
+      const targetUrl = `${UPSTREAM_BASE}/${path}${url.search}`;
       const response = await fetch(targetUrl, {
         headers: {
           "User-Agent":


### PR DESCRIPTION
## Summary
- add a new `search_full_text` MCP tool backed by the official upstream Volltextsuche
- parse and normalize full-text hits into law, paragraph, citation, snippet, score, and canonical URLs
- extend the Cloudflare proxy to allow `/cgi-bin/htsearch` and document the new MCP capability

## Verification
- `pnpm test`
- `pnpm typecheck`
- `pnpm --dir worker exec tsc --noEmit`
- live smoke query for `kaufvertrag` returned `BGB § 433` as the top hit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a live upstream full-text search tool (AND/OR methods, page 1–100) returning paginated, normalized results with titles, snippets, citations, URLs and relevance scores; registered as an MCP tool.

* **Documentation**
  * Updated service docs with the new tool specification: input parameters, output schema, result fields and pagination.

* **Tests**
  * Added parser tests covering multi-hit results and zero-results behavior.

* **Chores**
  * Allowed upstream search endpoint requests to forward original query strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->