### PR TITLE
fix(mcp): decode html entities in paragraph content

### DIFF
--- a/src/lib/gesetze/paragraph-source.test.ts
+++ b/src/lib/gesetze/paragraph-source.test.ts
@@ -20,6 +20,18 @@ const sampleHtml = `
   </html>
 `;
 
+const sampleHtmlWithEntities = `
+  <html>
+    <body>
+      <div class="jnheader">
+        <h1>B&#252;rgerliches Gesetzbuch (BGB)<br /><span class="jnenbez">&#167; 1</span>&#160;<span class="jnentitel">Beginn der Rechtsf&#228;higkeit</span></h1>
+      </div>
+      <div class="jurAbsatz">Die Rechtsf&#228;higkeit des Menschen beginnt mit der Vollendung der Geburt.</div>
+      <div id="blaettern_weiter"><a href="./__2.html">Weiter</a></div>
+    </body>
+  </html>
+`;
+
 void test("parseParagraphHtml extracts headers, content, footnotes, and navigation", () => {
   const record = parseParagraphHtml(sampleHtml, "bgb", "433");
 
@@ -37,4 +49,31 @@ void test("parseParagraphHtml extracts headers, content, footnotes, and navigati
   assert.match(record.content[0]?.markdown ?? "", /\[§ 434\]\(\/bgb\/434\)/);
   assert.equal(record.navigation.previous, "432");
   assert.equal(record.navigation.next, "434");
+});
+
+void test("parseParagraphHtml decodes HTML entities in text and markdown fields", () => {
+  const record = parseParagraphHtml(sampleHtmlWithEntities, "bgb", "1");
+
+  assert.ok(record);
+  assert.equal(
+    record.title,
+    "Bürgerliches Gesetzbuch (BGB) § 1 Beginn der Rechtsfähigkeit",
+  );
+  assert.equal(
+    record.headers[0]?.text,
+    "Bürgerliches Gesetzbuch (BGB) § 1 Beginn der Rechtsfähigkeit",
+  );
+  assert.equal(
+    record.headers[0]?.markdown,
+    "Bürgerliches Gesetzbuch (BGB) § 1 Beginn der Rechtsfähigkeit",
+  );
+  assert.equal(
+    record.content[0]?.text,
+    "Die Rechtsfähigkeit des Menschen beginnt mit der Vollendung der Geburt.",
+  );
+  assert.equal(
+    record.content[0]?.markdown,
+    "Die Rechtsfähigkeit des Menschen beginnt mit der Vollendung der Geburt.",
+  );
+  assert.equal(record.navigation.next, "2");
 });

--- a/src/lib/gesetze/paragraph-source.ts
+++ b/src/lib/gesetze/paragraph-source.ts
@@ -16,6 +16,28 @@ const REQUEST_HEADERS: Record<string, string> = {
 };
 
 const paragraphReferenceRegex = /(§{1,2}|&#167;)\s*(\d+[a-zA-Z]*)/g;
+const namedHtmlEntities: Record<string, string> = {
+  amp: "&",
+  apos: "'",
+  auml: "ä",
+  Auml: "Ä",
+  copy: "©",
+  euro: "€",
+  gt: ">",
+  hellip: "…",
+  lt: "<",
+  mdash: "—",
+  nbsp: "\u00a0",
+  ndash: "–",
+  Ouml: "Ö",
+  ouml: "ö",
+  para: "§",
+  quot: '"',
+  sect: "§",
+  szlig: "ß",
+  Uuml: "Ü",
+  uuml: "ü",
+};
 
 export interface ParagraphFragment {
   html: string;
@@ -64,7 +86,33 @@ export function buildParagraphSourceUrl(law: string, paragraph: string): string 
 }
 
 function normalizeText(value: string): string {
-  return value.replace(/\u00a0/g, " ").replace(/\s+/g, " ").trim();
+  return decodeHtmlEntities(value)
+    .replace(/\u00a0/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value.replace(
+    /&(#\d+|#x[0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]+);/g,
+    (entity: string, body: string) => {
+      if (body.startsWith("#x")) {
+        const codePoint = Number.parseInt(body.slice(2), 16);
+        return Number.isNaN(codePoint)
+          ? entity
+          : String.fromCodePoint(codePoint);
+      }
+
+      if (body.startsWith("#")) {
+        const codePoint = Number.parseInt(body.slice(1), 10);
+        return Number.isNaN(codePoint)
+          ? entity
+          : String.fromCodePoint(codePoint);
+      }
+
+      return namedHtmlEntities[body] ?? entity;
+    },
+  );
 }
 
 function htmlFragmentToMarkdown(html: string): string {
@@ -74,17 +122,11 @@ function htmlFragmentToMarkdown(html: string): string {
       .replace(
         /<a\s+[^>]*href="([^"]+)"[^>]*>(.*?)<\/a>/gi,
         (_match: string, href: string, label: string) =>
-          `[${normalizeText(label)}](${href})`,
+          `[${normalizeText(label)}](${decodeHtmlEntities(href)})`,
       )
       .replace(/<\/?(strong|b)>/gi, "**")
       .replace(/<\/?(em|i)>/gi, "_")
-      .replace(/<[^>]+>/g, "")
-      .replace(/&nbsp;/gi, " ")
-      .replace(/&amp;/gi, "&")
-      .replace(/&quot;/gi, '"')
-      .replace(/&#39;/gi, "'")
-      .replace(/&lt;/gi, "<")
-      .replace(/&gt;/gi, ">"),
+      .replace(/<[^>]+>/g, ""),
   );
 }
 

--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import * as z from "zod/v3";
 
 import {
@@ -92,6 +93,18 @@ function toParagraphResult(record: NonNullable<Awaited<ReturnType<typeof fetchPa
   };
 }
 
+function readOnlyAnnotations(
+  title: string,
+  openWorldHint = false,
+): ToolAnnotations {
+  return {
+    title,
+    readOnlyHint: true,
+    idempotentHint: true,
+    openWorldHint,
+  };
+}
+
 export function createMcpServer() {
   const server = new McpServer({
     name: "gesetze",
@@ -104,6 +117,7 @@ export function createMcpServer() {
       title: "Search Laws",
       description:
         "Search the local law directory by law code, title, full title, or description.",
+      annotations: readOnlyAnnotations("Search Laws"),
       inputSchema: {
         query: z.string().min(1).describe("Law search query"),
         limit: z.number().int().min(1).max(25).optional(),
@@ -148,6 +162,7 @@ export function createMcpServer() {
       title: "Resolve Reference",
       description:
         "Resolve a loose legal reference such as 'bgb 433', 'bgb§433', or '§ 433' into a canonical law and paragraph path.",
+      annotations: readOnlyAnnotations("Resolve Reference"),
       inputSchema: {
         input: z.string().min(1).describe("Loose legal reference"),
         currentLaw: z.string().optional().describe("Fallback law code"),
@@ -198,6 +213,7 @@ export function createMcpServer() {
     {
       title: "Get Law Info",
       description: "Get directory metadata for an exact law code.",
+      annotations: readOnlyAnnotations("Get Law Info"),
       inputSchema: {
         law: z.string().min(1).describe("Law code, e.g. bgb"),
       },
@@ -235,6 +251,7 @@ export function createMcpServer() {
       title: "Get Paragraph",
       description:
         "Fetch the exact text of a legal paragraph with headers, content, footnotes, and neighboring paragraph ids.",
+      annotations: readOnlyAnnotations("Get Paragraph", true),
       inputSchema: {
         law: z.string().min(1).describe("Law code, e.g. bgb"),
         paragraph: z.string().min(1).describe("Paragraph id, e.g. 433"),
@@ -267,6 +284,7 @@ export function createMcpServer() {
       title: "Get Paragraphs",
       description:
         "Fetch multiple exact legal paragraphs in a single tool call. Individual failures are returned per item.",
+      annotations: readOnlyAnnotations("Get Paragraphs", true),
       inputSchema: {
         items: z
           .array(
@@ -346,6 +364,7 @@ export function createMcpServer() {
       title: "Navigate Paragraph",
       description:
         "Resolve the previous or next valid paragraph using upstream navigation links instead of guessing numeric neighbors.",
+      annotations: readOnlyAnnotations("Navigate Paragraph", true),
       inputSchema: {
         law: z.string().min(1),
         paragraph: z.string().min(1),
@@ -417,6 +436,7 @@ export function createMcpServer() {
       title: "Extract Citations",
       description:
         "Extract simple paragraph citations such as '§ 433' from free text and optionally attach the current law as context.",
+      annotations: readOnlyAnnotations("Extract Citations"),
       inputSchema: {
         text: z.string().min(1),
         currentLaw: z.string().optional(),


### PR DESCRIPTION
## Summary
- decode numeric and named HTML entities when normalizing paragraph text and markdown
- reuse the decoder in markdown link generation so MCP structured content returns readable text
- add a regression test with upstream-style entity-encoded paragraph content

## Verification
- pnpm test
- pnpm typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTML entity decoding in legal document parsing. Text containing encoded special characters and Unicode symbols in law documents now displays in the correct readable format.

* **Chores**
  * Added comprehensive tool annotations to server-side operations, designating which operations are read-only and identifying idempotent actions to enhance API clarity and improve system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->