### PR TITLE
feat(legal): add datenschutz and impressum pages

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -13,6 +13,8 @@ import { Route as SitemapDotxmlRouteImport } from './routes/sitemap[.]xml'
 import { Route as RobotsDottxtRouteImport } from './routes/robots[.]txt'
 import { Route as OpengraphImageRouteImport } from './routes/opengraph-image'
 import { Route as McpRouteImport } from './routes/mcp'
+import { Route as ImpressumRouteImport } from './routes/impressum'
+import { Route as DatenschutzRouteImport } from './routes/datenschutz'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as LawParagraphRouteImport } from './routes/$law/$paragraph'
 import { Route as ApiLawParagraphRouteImport } from './routes/api/$law/$paragraph'
@@ -36,6 +38,16 @@ const OpengraphImageRoute = OpengraphImageRouteImport.update({
 const McpRoute = McpRouteImport.update({
   id: '/mcp',
   path: '/mcp',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ImpressumRoute = ImpressumRouteImport.update({
+  id: '/impressum',
+  path: '/impressum',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DatenschutzRoute = DatenschutzRouteImport.update({
+  id: '/datenschutz',
+  path: '/datenschutz',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -62,6 +74,8 @@ const LawParagraphOpengraphImageRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/datenschutz': typeof DatenschutzRoute
+  '/impressum': typeof ImpressumRoute
   '/mcp': typeof McpRoute
   '/opengraph-image': typeof OpengraphImageRoute
   '/robots.txt': typeof RobotsDottxtRoute
@@ -72,6 +86,8 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/datenschutz': typeof DatenschutzRoute
+  '/impressum': typeof ImpressumRoute
   '/mcp': typeof McpRoute
   '/opengraph-image': typeof OpengraphImageRoute
   '/robots.txt': typeof RobotsDottxtRoute
@@ -83,6 +99,8 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/datenschutz': typeof DatenschutzRoute
+  '/impressum': typeof ImpressumRoute
   '/mcp': typeof McpRoute
   '/opengraph-image': typeof OpengraphImageRoute
   '/robots.txt': typeof RobotsDottxtRoute
@@ -95,6 +113,8 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/datenschutz'
+    | '/impressum'
     | '/mcp'
     | '/opengraph-image'
     | '/robots.txt'
@@ -105,6 +125,8 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/datenschutz'
+    | '/impressum'
     | '/mcp'
     | '/opengraph-image'
     | '/robots.txt'
@@ -115,6 +137,8 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/datenschutz'
+    | '/impressum'
     | '/mcp'
     | '/opengraph-image'
     | '/robots.txt'
@@ -126,6 +150,8 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  DatenschutzRoute: typeof DatenschutzRoute
+  ImpressumRoute: typeof ImpressumRoute
   McpRoute: typeof McpRoute
   OpengraphImageRoute: typeof OpengraphImageRoute
   RobotsDottxtRoute: typeof RobotsDottxtRoute
@@ -162,6 +188,20 @@ declare module '@tanstack/react-router' {
       path: '/mcp'
       fullPath: '/mcp'
       preLoaderRoute: typeof McpRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/impressum': {
+      id: '/impressum'
+      path: '/impressum'
+      fullPath: '/impressum'
+      preLoaderRoute: typeof ImpressumRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/datenschutz': {
+      id: '/datenschutz'
+      path: '/datenschutz'
+      fullPath: '/datenschutz'
+      preLoaderRoute: typeof DatenschutzRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -209,6 +249,8 @@ const LawParagraphRouteWithChildren = LawParagraphRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  DatenschutzRoute: DatenschutzRoute,
+  ImpressumRoute: ImpressumRoute,
   McpRoute: McpRoute,
   OpengraphImageRoute: OpengraphImageRoute,
   RobotsDottxtRoute: RobotsDottxtRoute,

--- a/src/routes/datenschutz.tsx
+++ b/src/routes/datenschutz.tsx
@@ -1,0 +1,101 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/datenschutz")({
+  head: () => ({
+    meta: [
+      { title: "Datenschutz | Gesetz.sh" },
+      {
+        name: "description",
+        content:
+          "Datenschutzhinweise fuer Gesetz.sh mit einer knappen Beschreibung der verarbeiteten Daten.",
+      },
+    ],
+    links: [{ rel: "canonical", href: "https://gesetz.sh/datenschutz" }],
+  }),
+  component: PrivacyPage,
+});
+
+function PrivacyPage() {
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12">
+      <div className="mb-10">
+        <Link
+          to="/"
+          className="text-sm font-medium text-gray-500 hover:text-gray-900"
+        >
+          Zur Startseite
+        </Link>
+      </div>
+
+      <article className="prose prose-gray max-w-none">
+        <h1>Datenschutzerklaerung</h1>
+
+        <p>
+          Gesetz.sh ist ein statisches Such- und Nachschlageangebot fuer
+          deutsche Gesetze. Es gibt keine Benutzerkonten, keine Newsletter und
+          keine Kommentarfunktion.
+        </p>
+
+        <h2>Verantwortlicher</h2>
+        <p>
+          Nicolai Schmid
+          <br />
+          E-Mail: nicolai@schmid.uno
+        </p>
+
+        <h2>Welche Daten verarbeitet werden</h2>
+        <p>
+          Beim Aufruf der Website verarbeitet der Hosting-Anbieter technisch
+          erforderliche Verbindungsdaten, insbesondere IP-Adresse, Datum und
+          Uhrzeit, aufgerufene URL, uebertragene Datenmenge, Referrer,
+          Browsertyp und Betriebssystem. Die Verarbeitung ist erforderlich, um
+          die Website auszuliefern und die Sicherheit des Betriebs zu
+          gewaehrleisten.
+        </p>
+
+        <h2>Keine Nutzerkonten, keine Tracking-Profile</h2>
+        <p>
+          Gesetz.sh speichert keine Benutzerkonten und erstellt keine
+          personenbezogenen Nutzungsprofile. Es werden keine personenbezogenen
+          Daten zu Werbezwecken verkauft oder weitergegeben.
+        </p>
+
+        <h2>Rechtsgrundlage</h2>
+        <p>
+          Die Verarbeitung technisch notwendiger Daten erfolgt auf Grundlage von
+          Art. 6 Abs. 1 lit. f DSGVO. Das berechtigte Interesse liegt im
+          sicheren und stabilen Betrieb dieser Website.
+        </p>
+
+        <h2>Empfaenger</h2>
+        <p>
+          Daten koennen durch eingesetzte technische Dienstleister verarbeitet
+          werden, soweit dies fuer Hosting, Auslieferung und Sicherheit der
+          Website erforderlich ist.
+        </p>
+
+        <h2>Speicherdauer</h2>
+        <p>
+          Personenbezogene Daten werden nur so lange gespeichert, wie dies fuer
+          den technischen Betrieb, die Sicherheit oder gesetzliche Pflichten
+          erforderlich ist.
+        </p>
+
+        <h2>Ihre Rechte</h2>
+        <p>
+          Ihnen stehen nach der DSGVO insbesondere Rechte auf Auskunft,
+          Berichtigung, Loeschung, Einschraenkung der Verarbeitung,
+          Datenuebertragbarkeit und Widerspruch zu. Zudem besteht ein
+          Beschwerderecht bei einer Datenschutzaufsichtsbehoerde.
+        </p>
+
+        <h2>Kontakt</h2>
+        <p>
+          Bei Fragen zum Datenschutz wenden Sie sich bitte an:
+          <br />
+          nicolai@schmid.uno
+        </p>
+      </article>
+    </main>
+  );
+}

--- a/src/routes/impressum.tsx
+++ b/src/routes/impressum.tsx
@@ -1,0 +1,57 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/impressum")({
+  head: () => ({
+    meta: [
+      { title: "Impressum | Gesetz.sh" },
+      {
+        name: "description",
+        content: "Impressum von Gesetz.sh.",
+      },
+    ],
+    links: [{ rel: "canonical", href: "https://gesetz.sh/impressum" }],
+  }),
+  component: LegalNoticePage,
+});
+
+function LegalNoticePage() {
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12">
+      <div className="mb-10">
+        <Link
+          to="/"
+          className="text-sm font-medium text-gray-500 hover:text-gray-900"
+        >
+          Zur Startseite
+        </Link>
+      </div>
+
+      <article className="prose prose-gray max-w-none">
+        <h1>Impressum</h1>
+
+        <h2>Angaben gemaess § 5 DDG</h2>
+        <p>
+          Nicolai Schmid
+          <br />
+          [Strasse und Hausnummer ergaenzen]
+          <br />
+          [PLZ Ort ergaenzen]
+          <br />
+          Deutschland
+        </p>
+
+        <h2>Kontakt</h2>
+        <p>E-Mail: nicolai@schmid.uno</p>
+
+        <h2>Inhaltlich verantwortlich</h2>
+        <p>Nicolai Schmid</p>
+
+        <h2>Hinweis</h2>
+        <p>
+          Die postalische Anschrift im Impressum muss vor produktivem Betrieb
+          noch vervollstaendigt werden.
+        </p>
+      </article>
+    </main>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -107,7 +107,15 @@ function Home() {
       </div>
 
       <footer className="mt-20 border-t border-gray-100 pt-8 text-center text-sm text-gray-400">
-        Daten von gesetze-im-internet.de
+        <div>Daten von gesetze-im-internet.de</div>
+        <div className="mt-3 flex justify-center gap-4">
+          <Link to="/datenschutz" className="hover:text-gray-600">
+            Datenschutz
+          </Link>
+          <Link to="/impressum" className="hover:text-gray-600">
+            Impressum
+          </Link>
+        </div>
       </footer>
     </main>
   );


### PR DESCRIPTION
## Summary
- add slim /datenschutz and /impressum routes
- link both legal pages from the homepage footer
- regenerate the TanStack route tree

## Verification
- pnpm build

## Follow-up
- replace the postal address placeholders in /impressum before shipping publicly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Impressum page with legal and contact information
  * Added Datenschutz (privacy policy) page with data protection details
  * Added footer navigation links to both pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->