### PR TITLE
fix(mcp): mark read-only tools as non-destructive

### DIFF
--- a/src/lib/mcp-server.ts
+++ b/src/lib/mcp-server.ts
@@ -111,6 +111,7 @@ function readOnlyAnnotations(
 ): ToolAnnotations {
   return {
     title,
+    destructiveHint: false,
     readOnlyHint: true,
     idempotentHint: true,
     openWorldHint,


### PR DESCRIPTION
## Summary
- explicitly set `destructiveHint: false` for read-only MCP tools
- keep read-only and idempotent annotations unchanged
- make tool metadata easier for clients like OpenAI to classify correctly

## Testing
- not run (annotation-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server tool annotation attributes to enhance metadata structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->